### PR TITLE
Clarify recommended PHP label ("8.1" → "8.1 or higher")

### DIFF
--- a/language/en_EN.interface.php
+++ b/language/en_EN.interface.php
@@ -29,7 +29,7 @@ return array(
     'tr_melis_installer_layout_introduction_welcome_php_version_error' => 'Unable to proceed on installation, minimum PHP version required is <strong>%s</strong>, current version installed <strong>%s</strong>',
     'tr_melis_installer_layout_sys_req' => 'Step 1: System requirements',
     'tr_melis_installer_layout_sys_req_subtext' => 'Let\'s check your PHP installed variables and properties.',
-    'tr_melis_installer_layout_sys_req_php_version_recommended' => 'Recommended PHP 8.1',
+    'tr_melis_installer_layout_sys_req_php_version_recommended' => 'Recommended PHP 8.1 or higher',
     'tr_melis_installer_layout_sys_req_check_php_ext' => 'Checking required PHP extensions',
     'tr_melis_installer_layout_sys_req_check_php_env' => 'Checking PHP environment variables',
 

--- a/language/fr_FR.interface.php
+++ b/language/fr_FR.interface.php
@@ -30,7 +30,7 @@ return array(
 
     'tr_melis_installer_layout_sys_req' => 'Etape 1 : Configuration requise',
     'tr_melis_installer_layout_sys_req_subtext' => 'Regardons vos propriétés et variables PHP installées',
-    'tr_melis_installer_layout_sys_req_php_version_recommended' => 'Recommandé PHP 8.1',
+    'tr_melis_installer_layout_sys_req_php_version_recommended' => 'Recommandé PHP 8.1 ou supérieur',
     'tr_melis_installer_layout_sys_req_check_php_ext' => 'Vérification des extensions PHP requises',
     'tr_melis_installer_layout_sys_req_check_php_env' => 'Verification des variables de l\'Environnement PHP',
 


### PR DESCRIPTION
## What

The **System requirements** step of the installer shows a static label
`Recommended PHP 8.1` (EN) / `Recommandé PHP 8.1` (FR). On a supported, up‑to‑date
setup (e.g. **PHP 8.3**) this is confusing — it reads as if 8.1 were *the* target
version and anything else is off‑spec.

Melis actually supports a **range**: `composer.json` declares `"php": "^8.1|^8.3"`,
so PHP 8.2 / 8.3 are fully supported and preferable. This PR makes the label say so.

## Change

| File | Before | After |
|------|--------|-------|
| `language/en_EN.interface.php` | `Recommended PHP 8.1` | `Recommended PHP 8.1 or higher` |
| `language/fr_FR.interface.php` | `Recommandé PHP 8.1` | `Recommandé PHP 8.1 ou supérieur` |

Text‑only, no logic change. Both locales updated (the only two carrying the key).

## Why this wording

`8.1 or higher` matches the `^8.1|^8.3` constraint and won't go stale when a newer
PHP version is later supported.

## Out of scope (noted for maintainers)

Separately, `view/melis-installer/installer/index.phtml` still gates on
`$phpVersionRequired = '5.3.23';`, which no longer matches the `^8.1` requirement
(it would not block PHP < 8.1). Left untouched here to keep this PR text‑only —
happy to open a follow‑up if you'd like it bumped to `8.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)