### PR TITLE
Pre-fill DB connection form from MYSQL_* environment variables

### DIFF
--- a/src/Controller/InstallerController.php
+++ b/src/Controller/InstallerController.php
@@ -483,7 +483,46 @@ class InstallerController extends MelisAbstractActionController
             $data = $container['database'];
         }
 
+        // Nothing entered yet: pre-fill from environment variables when available.
+        // This lets containerized setups (e.g. Docker, which already define MYSQL_*)
+        // show the connection details in the form. The fields stay fully editable,
+        // and this is a no-op when those variables are not set.
+        if (empty($data)) {
+            $data = $this->loadDatabaseCredentialFromEnv();
+        }
+
         return $data;
+    }
+
+    /**
+     * Builds database credentials from MYSQL_* environment variables, if any.
+     * Returns an empty array when no relevant variable is defined.
+     * @return Array
+     */
+    protected function loadDatabaseCredentialFromEnv()
+    {
+        $host = getenv('MYSQL_HOST');
+        if ($host === false || $host === '') {
+            $host = getenv('MYSQL_HOSTNAME');
+        }
+        // Drop any ":port" — Melis expects a bare hostname for the DB connection.
+        if (is_string($host) && strpos($host, ':') !== false) {
+            $host = strstr($host, ':', true);
+        }
+
+        $env = [
+            'hostname' => ($host !== false) ? $host : '',
+            'database' => (getenv('MYSQL_DATABASE') !== false) ? getenv('MYSQL_DATABASE') : '',
+            'username' => (getenv('MYSQL_USER') !== false) ? getenv('MYSQL_USER') : '',
+            'password' => (getenv('MYSQL_PASSWORD') !== false) ? getenv('MYSQL_PASSWORD') : '',
+        ];
+
+        // Only pre-fill if at least one connection field is actually provided.
+        if ($env['hostname'] === '' && $env['database'] === '' && $env['username'] === '') {
+            return [];
+        }
+
+        return $env;
     }
 
     public function newEnvironmentFormAction()


### PR DESCRIPTION
## Why

The **Step 2 — Database connection** form always starts empty, so every user types
the host / database / user / password by hand. In containerized installs (Docker)
those values are *already* present as environment variables (`MYSQL_HOST`,
`MYSQL_DATABASE`, `MYSQL_USER`, `MYSQL_PASSWORD`), so the typing is pure friction.

## What

`loadDatabaseCredentialFromSession()` already feeds the form (`$view->setup2`) and
pre-fills it from the session. This PR adds a fallback: when the session has no DB
credentials yet, build them from the `MYSQL_*` environment variables.

```
Host=melis-db  Database=melis  Username=melis  Password=melis   ← shown ready-to-go
```

## Behaviour / safety

- **Editable**: only default values are set; the user can still change anything.
- **Bare hostname**: any `:port` suffix is stripped (Melis expects a host without a
  port for the DB connection).
- **No-op outside containers**: if none of the variables are set, the form stays
  empty exactly as before — non-Docker installs are unaffected.
- Session values still take precedence (re-editing keeps what you entered).

## Context

Comes from packaging Melis as ready-to-run Docker images: the container already
knows the DB coordinates, so the installer may as well show them. Pairs with the
`utf8mb4_general_ci` collation requirement enforced by the installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)