### PR TITLE
Add explicit nullable param types (PHP 8.4 deprecation)

### DIFF
--- a/src/Form/View/Helper/MelisFieldCollection.php
+++ b/src/Form/View/Helper/MelisFieldCollection.php
@@ -10,7 +10,7 @@ class MelisFieldCollection extends FormCollection
     protected $shouldWrap = false;
     protected $defaultElementHelper = 'MelisFieldRow';
 
-    public function __invoke(ElementInterface $element = null, $wrap = false)
+    public function __invoke(?ElementInterface $element = null, $wrap = false)
     {
         $wrap = $this->shouldWrap;
 


### PR DESCRIPTION
## What

PHP 8.4 deprecates **implicitly nullable parameters** (`Type $x = null`). This makes them explicit (`?Type $x = null`) in `src/`.

## Safety

**Behaviour-preserving** (PHP already treats `Type $x = null` as nullable). Generated with PHP-CS-Fixer (`nullable_type_declaration_for_default_null_value`), `php -l` clean — `?`-only changes, no logic change.

## Context

Part of the PHP 8.4 support effort (melisplatform/melis-core#24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)