### PR TITLE
Fix PDO::MYSQL_ATTR_INIT_COMMAND deprecation on PHP 8.5 (version-guarded)

### DIFF
--- a/src/Controller/InstallerController.php
+++ b/src/Controller/InstallerController.php
@@ -1383,6 +1383,9 @@ class InstallerController extends MelisAbstractActionController
                     $fileName = $installHelper->getMelisPlatform() . '.php';
 
                     // Database connection configuration
+                    // PDO::MYSQL_ATTR_INIT_COMMAND is deprecated on PHP 8.5+; Pdo\Mysql::ATTR_INIT_COMMAND
+                    // only exists on 8.4+. Same integer value either way (written into the template).
+                    $initCommand = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_INIT_COMMAND : \PDO::MYSQL_ATTR_INIT_COMMAND;
                     $dbConnFile = file_get_contents(__DIR__ . '/../../etc/DatabaseConnection');
                     $dbConn = sprintf(
                         $dbConnFile,
@@ -1390,7 +1393,7 @@ class InstallerController extends MelisAbstractActionController
                         $database['database'],
                         $database['username'],
                         $database['password'],
-                        PDO::MYSQL_ATTR_INIT_COMMAND
+                        $initCommand
                     );
 
                     if (is_writable('config/autoload/platforms/'))

--- a/src/Service/InstallHelperService.php
+++ b/src/Service/InstallHelperService.php
@@ -119,13 +119,16 @@ class InstallHelperService extends AbstractService
             $isConnected = 1;
 
             try {
+                // PDO::MYSQL_ATTR_INIT_COMMAND is deprecated on PHP 8.5+; the namespaced
+                // Pdo\Mysql::ATTR_INIT_COMMAND only exists on 8.4+. Same value either way.
+                $initCommand = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_INIT_COMMAND : \PDO::MYSQL_ATTR_INIT_COMMAND;
                 $dbAdapter = new DbAdapter(array(
                     'driver' =>  'Pdo',
                     'dsn'   =>   'mysql:dbname=INFORMATION_SCHEMA;host='.$host,
                     'username' => $user,
                     'password' => $pass,
                     'driver_options' => array(
-                        PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES 'UTF8MB4'"
+                        $initCommand => "SET NAMES 'UTF8MB4'"
                     ),
                 ));
 
@@ -169,10 +172,13 @@ class InstallHelperService extends AbstractService
     public function setDbAdapter($config)
     {
         if(is_array($config)) {
+            // PDO::MYSQL_ATTR_INIT_COMMAND is deprecated on PHP 8.5+; Pdo\Mysql::ATTR_INIT_COMMAND
+            // only exists on 8.4+. Same value either way.
+            $initCommand = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_INIT_COMMAND : \PDO::MYSQL_ATTR_INIT_COMMAND;
             $this->odbAdapter = new DbAdapter(array_merge(array(
                 'driver' => 'Pdo_Mysql',
                 'driver_options' => array(
-                    PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES 'UTF8MB4'"
+                    $initCommand => "SET NAMES 'UTF8MB4'"
                 )
             ), $config));
 


### PR DESCRIPTION
## Problem
On **PHP 8.5**, `PDO::MYSQL_ATTR_INIT_COMMAND` is deprecated (use `Pdo\Mysql::ATTR_INIT_COMMAND`). The emitted `E_DEPRECATED` notice gets printed into the installer's `testDatabaseConnection` response, so the JSON the wizard parses is corrupted and the **DB-connection step fails on 8.5** — even though the connection itself succeeds (`success:1`). It also surfaces wherever these adapters are built.

## Fix
`Pdo\Mysql::ATTR_INIT_COMMAND` only exists on PHP **8.4+**, but this package supports `^8.1`, so a direct swap would fatal on 8.1–8.3. The attribute id is resolved through a version guard (both constants equal `1002`):

```php
$initCommand = \PHP_VERSION_ID >= 80400
    ? \Pdo\Mysql::ATTR_INIT_COMMAND
    : \PDO::MYSQL_ATTR_INIT_COMMAND;
```

Applied at the 3 usages:
- `src/Service/InstallHelperService.php::checkMysqlConnection()`
- `src/Service/InstallHelperService.php::setDbAdapter()`
- `src/Controller/InstallerController.php` (the `etc/DatabaseConnection` template, `%d` placeholder)

## Compatibility & verification
- **No behaviour change** on any supported version — the resolved value is `1002` everywhere.
- `php -l` clean on **8.1, 8.3, 8.5**.
- On 8.5: the guarded form resolves to `1002` with **no deprecation**; the old form reproduces the deprecation.
- The guard's 8.4+ branch is never evaluated on older PHP, so no undefined-class error.

## Context
Found while bringing Melis up on PHP 8.5 end-to-end (full install reached the working back-office). Part of the 8.5 effort tracked in melisplatform/melis-core#28; infra-side changes are in melisplatform/melis-docker#9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)